### PR TITLE
Fix for health check type attribute value

### DIFF
--- a/app/services/cloud_foundry.rb
+++ b/app/services/cloud_foundry.rb
@@ -158,7 +158,7 @@ class CloudFoundry
           app["buildpack"] = app_manifest["qafire"]["buildpack"]
         end
         if %w(none process).include? app_manifest["qafire"]["health_check_type"]
-          app["health_check_type"] = "process"
+          app["health_check_type"] = "none"
         end
       end
       result = RestClient.post("#{@cf_api}/v2/apps",

--- a/spec/services/cloud_foundry_spec.rb
+++ b/spec/services/cloud_foundry_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe CloudFoundry, type: :service do
 
     context 'health check disabled' do
       let(:manifest_health_check) { 'none' }
-      let(:requested_health_check) { 'process' }
+      let(:requested_health_check) { 'none' }
 
       context '200 megabytes' do
         let(:manifest_memory) { '200' }


### PR DESCRIPTION
If health check should be disabled, then (contra the docs) the value should be 'none' rather than 'process'.

Ping @maxious @tobyhede 