### PR TITLE
Fix for excessive memory use

### DIFF
--- a/app/services/cloud_foundry.rb
+++ b/app/services/cloud_foundry.rb
@@ -153,13 +153,13 @@ class CloudFoundry
       end
 
       if app_manifest["qafire"]["deploy_memory"]
-        app["memory"] = to_megabytes(app_manifest["qafire"]["memory"])
+        app["memory"] = to_megabytes(app_manifest["qafire"]["deploy_memory"])
       elsif app_manifest["qafire"]["memory"]
         app["memory"] = to_megabytes(app_manifest["qafire"]["memory"])
       end
 
       if app_manifest["qafire"]["disk_quota"]
-        app["disk_quota"] = to_megabytes(app_manifest["qafire"]["memory"])
+        app["disk_quota"] = to_megabytes(app_manifest["qafire"]["disk_quota"])
       end
 
       if %w(none process).include? app_manifest["qafire"]["health_check_type"]

--- a/app/services/cloud_foundry.rb
+++ b/app/services/cloud_foundry.rb
@@ -134,7 +134,7 @@ class CloudFoundry
         app["memory"] = to_megabytes(app["memory"])
       end
       if app["disk_quota"]
-        app["disk_quota"] = to_megabytes(app["memory"])
+        app["disk_quota"] = to_megabytes(app["disk_quota"])
       end
       app["name"] = app_name
     end
@@ -151,9 +151,13 @@ class CloudFoundry
       if app_manifest["qafire"]["buildpack"]
         app["buildpack"] = app_manifest["qafire"]["buildpack"]
       end
-      if app_manifest["qafire"]["memory"]
+
+      if app_manifest["qafire"]["deploy_memory"]
+        app["memory"] = to_megabytes(app_manifest["qafire"]["memory"])
+      elsif app_manifest["qafire"]["memory"]
         app["memory"] = to_megabytes(app_manifest["qafire"]["memory"])
       end
+
       if app_manifest["qafire"]["disk_quota"]
         app["disk_quota"] = to_megabytes(app_manifest["qafire"]["memory"])
       end
@@ -226,15 +230,19 @@ class CloudFoundry
     puts("push complete for #{app_name}")
   end
 
-  def self.start_app(app_name)
+  def self.start_app(app_name, memory = nil)
     #start app
     app = find_first_app(app_name)
     if app['entity']['state'] == 'STARTED'
       stop_app(app_name)
     end
     app_guid = app['metadata']['guid']
-    result = RestClient.put("#{@cf_api}/v2/apps/#{app_guid}?async=true", {state: "STARTED"}.to_json, @headers)
-    puts("start complete for #{app_name}")
+
+    params = { state: 'STARTED' }
+    params[:memory] = to_megabytes(memory) if memory.present?
+
+    result = RestClient.put("#{@cf_api}/v2/apps/#{app_guid}?async=true", params.to_json, @headers)
+    puts("start complete for #{app_name} with params #{params.as_json}")
   end
 
   def self.stop_app(app_name)

--- a/app/services/server.rb
+++ b/app/services/server.rb
@@ -35,7 +35,7 @@ class Server
 
         DatabaseService.new(app_manifest, @deploy).perform!
 
-        CloudFoundry.start_app(@deploy.full_name)
+        CloudFoundry.start_app(@deploy.full_name, app_manifest.dig('qafire', 'memory'))
 
         if @deploy.trigger == 'github'
           puts 'Posting status to github'


### PR DESCRIPTION
Fix for #108. With these changes, if the app manifest contains an extra attribute (`deploy_memory` within the `qafire` block) then this will be used as the memory during deployment. The app then reverts to the amount of memory in the `memory` attribute (as before). 

This seems to work OK but as I'm relatively new to QA Fire it'd be great to get some more 👀 on it.