### PR TITLE
Fixes for Dashboard

### DIFF
--- a/app/services/github_status_service.rb
+++ b/app/services/github_status_service.rb
@@ -1,6 +1,7 @@
 class GithubStatusService
-  def initialize(deploy)
+  def initialize(deploy, success)
     @deploy = deploy
+    @success = success
   end
 
   # https://developer.github.com/v3/repos/statuses/
@@ -9,10 +10,26 @@ class GithubStatusService
       github = Octokit::Client.new(access_token: @deploy.user.github_token)
       info = {
           target_url: @deploy.decorate.url,
-          description: 'Your branch is now ready for testing',
+          description: message,
           context: 'QA Fire',
       }
-      github.create_status(@deploy.repository, @deploy.sha, 'success', info)
+      github.create_status(@deploy.repository, @deploy.sha, status, info)
+    end
+  end
+
+  def message
+    if @success
+      'Your branch is now ready for testing'
+    else
+      'Deployment timed out'
+    end
+  end
+
+  def status
+    if @success
+      'success'
+    else
+      'failure'
     end
   end
 end

--- a/app/services/server.rb
+++ b/app/services/server.rb
@@ -35,11 +35,12 @@ class Server
 
         DatabaseService.new(app_manifest, @deploy).perform!
 
-        CloudFoundry.start_app(@deploy.full_name, app_manifest.dig('qafire', 'memory'))
+        CloudFoundry.start_app(@deploy.full_name)
+        deploy_success = CloudFoundry.wait_for_deploy_status @deploy
 
         if @deploy.trigger == 'github'
           puts 'Posting status to github'
-          GithubStatusService.new(@deploy).perform!
+          GithubStatusService.new(@deploy, deploy_success).perform!
         end
 
         @deploy.update(deployed_at: DateTime.now)


### PR DESCRIPTION
Three things: 

- Report status to GitHub only once instance is deployed; 
- Allow for QAFire-specific env vars in app manifest;
- Backed out of the memory reduction stuff as it wasn't working.

On that last point - scaling the app (i.e. doing a `PUT /v2/apps/#{guid}` with updated `memory` param) caused a rebuild - and thus, requires the same amount of memory as a normal push, or close to. If someone can figure out how to scale without rebuilding, great (as I've worked out how to run something only once app is finished deploying - as per point one above, see `CloudFoundry::wait_for_deploy_status` in the code)... but I've been wracking my brains and reading the api docs over & over and going a little crazy.